### PR TITLE
Fix 401 on device APIs: switch to Basic auth scheme

### DIFF
--- a/custom_components/rinnai_smart/rinnai_client.py
+++ b/custom_components/rinnai_smart/rinnai_client.py
@@ -38,7 +38,7 @@ class HTTPClient:
         return True
 
     async def _get_devices(self):
-        headers = {"Authorization": f"Bearer {self._token}"}
+        headers = {"Authorization": f"Basic {self._token}"}
         return await self._get_url("/app/V1/device/list", headers=headers)
 
     async def get_devices(self) -> list[dict] | None:
@@ -66,7 +66,7 @@ class HTTPClient:
         return devices_info
 
     async def _get_device_information(self, device_id: str):
-        headers = {"Authorization": f"Bearer {self._token}"}
+        headers = {"Authorization": f"Basic {self._token}"}
         params = {"deviceId": device_id}
         return await self._get_url(
             "/app/V1/device/processParameter", headers=headers, params=params
@@ -198,9 +198,9 @@ class RinnaiClient:
         MAX_BACKOFF = 3600
         NEED_BACKOFF_SECONDS = datetime.timedelta(seconds=60)
         backoff = BACKOFF_INIT
-        now = datetime.datetime.now()
         subscribes = []
         while True:
+            now = datetime.datetime.now()
             try:
                 LOGGER.info("Trying to connect to MQTT server...")
                 await self._mqtt_client.run(ssl_context, subscribes)


### PR DESCRIPTION
## Summary

The integration currently fails to set up with a `401 Unauthorized` on `GET /app/V1/device/list`:

```
aiohttp.client_exceptions.ClientResponseError: 401, message='', url='https://iot.rinnai.com.cn/app/V1/device/list'
```

Login still succeeds and returns a valid JWT, but the device endpoints reject the `Authorization: Bearer <token>` header. Rinnai changed the server-side auth scheme: the official app now sends **`Authorization: Basic <token>`** (same login JWT, only the scheme changed).

Verified by:
- Decompiling the latest official APK — `KitInterceptor` adds `"Basic " + token` to every authenticated request.
- Testing against the live API: `Basic` → `200` with the device list, `Bearer` → `401`.

This affects all users; the integration can't load until the scheme is fixed.

## Changes

- `rinnai_client.py`: use `Basic` instead of `Bearer` for `device/list` and `device/processParameter`.
- `rinnai_client.py`: fix reconnect backoff in `RinnaiClient.run()` — `now` was captured once before the loop and never updated, so after the first 60s the elapsed-time check always reset the backoff and the exponential backoff never engaged. Moved the timestamp inside the loop so it marks each connection attempt's start.

MQTT auth is unaffected (it uses username + MD5 password, not this token).

## Test plan

- [x] `device/list` returns 200 with `Basic` scheme against the live API
- [x] Integration loads and devices appear in Home Assistant
- [ ] Confirm reconnect/backoff behavior on flapping MQTT connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)